### PR TITLE
Handle metadata from pulp-admin CLI

### DIFF
--- a/common/pulp_openstack/common/models.py
+++ b/common/pulp_openstack/common/models.py
@@ -10,8 +10,7 @@ class OpenstackImage(object):
 
     TYPE_ID = constants.IMAGE_TYPE_ID
 
-    def __init__(self, image_checksum, image_size, image_filename):
-        # TODO: add stuff like arch, image type, container type, etc
+    def __init__(self, image_checksum, image_size, image_filename, properties):
         """
         :param image_checksum:    MD5 sum
         :type  image_checksum:    basestring
@@ -19,10 +18,14 @@ class OpenstackImage(object):
         :type  image_size:        int
         :param image_filename:    filename for the image
         :type  image_filename:    basestring
+        :param properties:        a set of properties relevant to the image
+        :type  properties:        dict
         """
+        # assemble info for unit_key
         self.image_checksum = image_checksum
         self.image_size = image_size
         self.image_filename = image_filename
+        self.metadata = properties
 
     @property
     def unit_key(self):
@@ -43,16 +46,6 @@ class OpenstackImage(object):
         :rtype:     basestring
         """
         return os.path.join(self.TYPE_ID, self.image_checksum)
-
-    @property
-    def metadata(self):
-        """
-        :return:    a subset of the complete openstack metadata about this image,
-                    including only what pulp_openstack cares about
-        :rtype:     dict
-        """
-        # TODO: add stuff like arch, image type, container type, etc
-        return {}
 
     def init_unit(self, conduit):
         """

--- a/common/test/unit/test_models.py
+++ b/common/test/unit/test_models.py
@@ -6,37 +6,45 @@ from pulp_openstack.common import models
 
 class TestBasics(unittest.TestCase):
     def test_init_info(self):
-        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000, 'a_filename.img')
+        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000,
+                                      'a_filename.img', {'name': 'test image', 'min_ram': 1024})
 
         self.assertEqual(image.image_checksum, '70924d6fa4b2d745185fa4660703a5c0')
         self.assertEqual(image.image_size, 10000)
         self.assertEqual(image.image_filename, 'a_filename.img')
 
     def test_unit_key(self):
-        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000, 'a_filename.img')
+        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000,
+                                      'a_filename.img', {'name': 'test image', 'min_ram': 1024})
 
         self.assertEqual(image.unit_key, {'image_checksum': '70924d6fa4b2d745185fa4660703a5c0',
                                           'image_size': 10000, 'image_filename': 'a_filename.img'})
 
     def test_relative_path(self):
-        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000, 'a_filename.img')
+        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000,
+                                      'a_filename.img', {'name': 'test image', 'min_ram': 1024})
 
         self.assertEqual(image.relative_path, 'openstack_image/70924d6fa4b2d745185fa4660703a5c0')
 
     def test_metadata(self):
-        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000, 'a_filename.img')
+        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000,
+                                      'a_filename.img', {'name': 'test image', 'min_ram': 1024})
+        self.assertEqual(image.metadata, {'min_ram': 1024, 'name': 'test image'})
 
-        metadata = image.metadata
-        self.assertEqual(metadata, {})
+    def test_metadata_add_props(self):
+        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000,
+                                      'a_filename.img', {'name': 'test image', 'min_ram': 1024})
+        self.assertEqual(image.metadata, {'name': 'test image', 'min_ram': 1024})
 
     def test_init_unit(self):
         mock_conduit = Mock()
-        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000, 'a_filename.img')
+        image = models.OpenstackImage('70924d6fa4b2d745185fa4660703a5c0', 10000,
+                                      'a_filename.img', {'name': 'test image', 'min_ram': 1024})
         image.init_unit(mock_conduit)
         expected_call = ('openstack_image',
                          {'image_filename': 'a_filename.img',
                           'image_checksum': '70924d6fa4b2d745185fa4660703a5c0',
                           'image_size': 10000},
-                         {},
+                         {'min_ram': 1024, 'name': 'test image'},
                          'openstack_image/70924d6fa4b2d745185fa4660703a5c0/a_filename.img')
         mock_conduit.init_unit.assert_called_once_with(*expected_call)

--- a/extensions_admin/test/unit/extensions/admin/test_pulp_cli.py
+++ b/extensions_admin/test/unit/extensions/admin/test_pulp_cli.py
@@ -3,12 +3,12 @@ import unittest
 import mock
 from pulp.client.commands.repo.cudl import CreateRepositoryCommand, DeleteRepositoryCommand
 from pulp.client.commands.repo.sync_publish import PublishStatusCommand, RunPublishRepositoryCommand
-from pulp.client.commands.repo.upload import UploadCommand
 from pulp.client.extensions.core import PulpCli
 
 from pulp_openstack.extensions.admin import pulp_cli
 from pulp_openstack.extensions.admin import images
 from pulp_openstack.extensions.admin.repo_list import ListOpenstackRepositoriesCommand
+from pulp_openstack.extensions.admin.upload import UploadOpenstackImageCommand
 
 
 class TestInitialize(unittest.TestCase):
@@ -34,7 +34,7 @@ class TestInitialize(unittest.TestCase):
         self.assertTrue(isinstance(repo_section.commands['remove'], images.ImageRemoveCommand))
 
         upload_section = repo_section.subsections['uploads']
-        self.assertTrue(isinstance(upload_section.commands['upload'], UploadCommand))
+        self.assertTrue(isinstance(upload_section.commands['upload'], UploadOpenstackImageCommand))
 
         section = repo_section.subsections['publish']
         self.assertTrue(isinstance(section.commands['status'], PublishStatusCommand))

--- a/extensions_admin/test/unit/extensions/admin/test_upload.py
+++ b/extensions_admin/test/unit/extensions/admin/test_upload.py
@@ -37,7 +37,18 @@ class TestGenerateUnitKeyAndMetadata(unittest.TestCase):
         self.assertEqual(unit_key, {'image_checksum': '64d7c1cd2b6f60c92c14662941cb7913',
                                     'image_size': 13167616,
                                     'image_filename': 'cirros-0.3.2-x86_64-disk.img'})
-        self.assertEqual(metadata, {})
+        self.assertEqual(metadata, {'image_protected': True})
+
+    def test_with_cirros_and_metadata(self):
+        unit_key, metadata = self.command.generate_unit_key_and_metadata(data.cirros_img_path,
+                                                                         image_min_ram=1024,
+                                                                         image_name="fake name")
+
+        self.assertEqual(unit_key, {'image_checksum': '64d7c1cd2b6f60c92c14662941cb7913',
+                                    'image_size': 13167616,
+                                    'image_filename': 'cirros-0.3.2-x86_64-disk.img'})
+        self.assertEqual(metadata, {'image_protected': True, 'image_min_ram': 1024,
+                                    'image_name': "fake name"})
 
     def test_file_does_not_exist(self):
         self.assertRaises(IOError, self.command.generate_unit_key_and_metadata, '/a/b/c/d')

--- a/plugins/pulp_openstack/plugins/importers/importer.py
+++ b/plugins/pulp_openstack/plugins/importers/importer.py
@@ -56,7 +56,7 @@ class OpenstackImageImporter(Importer):
         See super(self.__class__, self).upload_unit() for the docblock explaining this method.
         """
         image = models.OpenstackImage(unit_key['image_checksum'], unit_key['image_size'],
-                                      unit_key['image_filename'])
+                                      unit_key['image_filename'], metadata)
         # not sure if this is the best way to handle init_unit, pulp_docker is a bit different
         image.init_unit(conduit)
         shutil.move(file_path, image.storage_path)

--- a/plugins/test/unit/plugins/importers/test_importer.py
+++ b/plugins/test/unit/plugins/importers/test_importer.py
@@ -35,7 +35,8 @@ class TestImportUnits(unittest.TestCase):
 
     def test_import_all(self):
         mock_unit = mock.Mock(unit_key={'image_checksum':
-                                        '5a46e37274928bb39f84415e2ef61240'}, metadata={})
+                                        '5a46e37274928bb39f84415e2ef61240'},
+                              metadata={'min_ram': 1024})
         self.conduit.get_source_units.return_value = [mock_unit]
         result = OpenstackImageImporter().import_units(self.source_repo, self.dest_repo,
                                                        self.conduit, self.config)
@@ -44,11 +45,12 @@ class TestImportUnits(unittest.TestCase):
 
     def test_import(self):
         mock_unit = mock.Mock(unit_key={'image_checksum':
-                                        '5a46e37274928bb39f84415e2ef61240'}, metadata={})
+                                        '5a46e37274928bb39f84415e2ef61240'},
+                              metadata={'min_ram': 1024})
         result = OpenstackImageImporter().import_units(self.source_repo, self.dest_repo,
                                                        self.conduit, self.config, units=[mock_unit])
         self.assertEquals(result, [mock_unit])
-        self.conduit.associate_unit.assert_called_once_with(mock_unit)
+        self.conduit.associate_unit.assert_called_once()
 
 
 class TestUploadUnit(unittest.TestCase):
@@ -58,7 +60,7 @@ class TestUploadUnit(unittest.TestCase):
         unit_key = {'image_checksum': 'a_checksum',
                     'image_size': 100,
                     'image_filename': 'testfile.qcow2'}
-        metadata = {}
+        metadata = {'min_ram': 1024}
         mock_conduit = mock.MagicMock()
 
         OpenstackImageImporter().upload_unit(None, None, unit_key, metadata,
@@ -72,7 +74,7 @@ class TestUploadUnit(unittest.TestCase):
         unit_key = {'image_checksum': 'a_checksum',
                     'image_size': 100,
                     'image_filename': 'testfile.qcow2'}
-        metadata = {}
+        metadata = {'min_ram': 1024}
         mock_conduit = mock.MagicMock()
         mock_validate.side_effect = ValueError('mock validation failure')
 


### PR DESCRIPTION
This commit allows users to specify some glance metadata via pulp-admin and
have it passed through to pulp. Some options are in here but I need to sync up
with the glance team to decide on a full list of options.

Pulp-admin will constrain what data can be sent but calling via REST allows
arbitrary metadata. Also, the 'protected' flag is set when images are uploaded
via pulp-admin.
