### PR TITLE
remove pep257 requirement from tests

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -19,20 +19,6 @@ retval = subprocess.call(['flake8', '--config', config_file, PROJECT_DIR])
 if retval != 0:
     sys.exit(retval)
 
-# the warn ignore codes should be a subset of the fail codes
-# GOAL: remove all ignores, always fail if these exist
-pep257_warn_ignore_codes = 'D100,D103,D200,D202,D203,D205,D400,D401,D402'
-pep257_fail_ignore_codes = 'D100,D102,D103,D200,D202,D203,D205,D400,D401,D402'
-
-print "checking pep257 for warnings, ignoring %s" % pep257_warn_ignore_codes
-subprocess.call(['pep257', '--ignore=' + pep257_warn_ignore_codes])
-
-print "checking pep257 for failures, ignoring %s" % pep257_fail_ignore_codes
-retval = subprocess.call(['pep257', '--ignore=' + pep257_fail_ignore_codes])
-
-if retval != 0:
-    sys.exit(retval)
-
 print "done, checking sphinx param docs.."
 
 # Ensure that all doc strings are present

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,4 +3,3 @@ flake8
 mock
 nose
 nosexcover
-pep257

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -25,7 +25,6 @@ pip install isodate
 pip install celery
 pip install okaara
 pip install coverage
-pip install pep257
 pip install python-glanceclient
 pip install python-keystoneclient
 


### PR DESCRIPTION
No other plugin uses this, and it's currently breaking due to a change
in pep257 that would require yet another exception to be added. As far
as I can tell, we've added exceptions for every error that pep257 might
tell us about, so this change is effectively a no-op.

I do think docstrings are good, and that we should have them, so I'm
referring to a story that I just made about getting docstrings added to
pulp. Discussions of the pro/cons of requiring docstrings should
probably happen there.

Furthermore, this commit can be used as a reference for seeing how we
integrated pep257 once upon a time.

re #1718
https://pulp.plan.io/issues/1718